### PR TITLE
Use SVD instead of Eigendecomposition for greater numerical stability

### DIFF
--- a/cma/core.py
+++ b/cma/core.py
@@ -306,6 +306,9 @@ class CMA(object):
             # ----------------------------------------
             # (5) Update B and D: eigen decomposition
             # ----------------------------------------
+            diag_D, B, _ = tf.linalg.svd(C)
+            D = tf.linalg.tensor_diag(diag_D)
+            """
             try:
                 eigenvalues, eigenvectors = tf.linalg.eigh(C)
             except tf.errors.InvalidArgumentError as e:
@@ -316,6 +319,7 @@ class CMA(object):
             diag_D = tf.sqrt(eigenvalues)
             D = tf.linalg.tensor_diag(diag_D)
             B = eigenvectors
+            """
 
             # -------------------------------
             # (6) Assign new variable values


### PR DESCRIPTION
https://github.com/srom/cma-es/issues/1

> Sometimes in my experiments the eigendecomposition fails when the initial state is chosen poorly. Wouldn't it make sense to use the SVD instead of the eigendecomposition?